### PR TITLE
Makuri Island Update (July 2021)

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2780,5 +2780,24 @@ export const routes: ReadonlyArray<Route> = [
     sports: ["cycling", "running"],
     eventOnly: false,
     id: 3367186349,
-  }
+  },
+  {
+    world: "makuri-islands",
+    name: "Kappa Quest Reverse",
+    distance: 9.07,
+    elevation: 141,
+    leadInDistance: 5.15,
+    leadInElevation: 130.7,
+    experience: 180,
+    segments: ["temple-kom-from-castle-side"],
+    stravaSegmentId: 29009500,
+    stravaSegmentUrl: "https://www.strava.com/segments/29009500",
+    zwiftInsiderUrl: "https://zwiftinsider.com/route/kappa-quest-reverse",
+    whatsOnZwiftUrl:
+      "https://whatsonzwift.com/world/makuri-islands/route/kappa-quest-reverse",
+    slug: "kappa-quest-reverse",
+    sports: ["cycling", "running"],
+    eventOnly: false,
+    id: 1454553567,
+  },
 ];

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2762,4 +2762,23 @@ export const routes: ReadonlyArray<Route> = [
     eventOnly: false,
     id: 2653858696,
   },
+  {
+    world: "makuri-islands",
+    name: "Suki's Playground",
+    distance: 18.31,
+    elevation: 149.8,
+    leadInDistance: 0.22,
+    leadInElevation: 0.2,
+    experience: 370,
+    segments: ["country-sprint"],
+    stravaSegmentId: 29009511,
+    stravaSegmentUrl: "https://www.strava.com/segments/29009511",
+    zwiftInsiderUrl: "https://zwiftinsider.com/route/sukis-playground",
+    whatsOnZwiftUrl:
+      "https://whatsonzwift.com/world/makuri-islands/route/suki-s-playground",
+    slug: "sukis-playground",
+    sports: ["cycling", "running"],
+    eventOnly: false,
+    id: 3367186349,
+  }
 ];


### PR DESCRIPTION
2 new routes:

- Suki's Playground
- Kappa Quest Reverse
